### PR TITLE
Create a route for banning a user by the user's id

### DIFF
--- a/src/common/guards/admin.guard.ts
+++ b/src/common/guards/admin.guard.ts
@@ -1,0 +1,18 @@
+import { Injectable, CanActivate, ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Request } from 'express';
+import { SessionUser } from '../types/session-user.type';
+import { Permission } from '../../users/users.entity';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<Request>();
+    const user = request.user as SessionUser;
+
+    if (user.permission !== Permission.Admin) {
+      throw new ForbiddenException();
+    }
+
+    return true;
+  }
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -5,6 +5,7 @@ import { Permission } from './users.entity';
 import { RegisterUserDto } from './dto/register-user.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { AuthenticatedGuard } from '../common/guards/authenticated.guard';
+import { AdminGuard } from '../common/guards/admin.guard';
 import { ValidationPipe } from '../common/pipes/validation.pipe'
 import { IdValidationPipe } from '../common/pipes/id-validation.pipe';
 import { SessionUser } from '../common/types/session-user.type';
@@ -56,5 +57,14 @@ export class UsersController {
       autobiography: user.autobiography,
       permission: user.permission,
     });
+  }
+
+  @UseGuards(AuthenticatedGuard, AdminGuard)
+  @Post(':id/ban')
+  async banUser(@Param('id', IdValidationPipe) userId: number) {
+    const result = await this.usersService.banUserById(userId);
+    if (!result) {
+      throw new NotFoundException();
+    }
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { User } from './users.entity';
+import { User, Status } from './users.entity';
 import { Repository } from 'typeorm';
 import { RegisterUserDto } from './dto/register-user.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
@@ -39,7 +39,7 @@ export class UsersService {
   }
 
   async updateProfile(updateProfileDto: UpdateProfileDto, userId: number): Promise<boolean> {
-    if (await this.userRepository.count({ id: userId }) === 0) {
+    if (!(await this.checkUserExistenceById(userId))) {
       return false;
     }
 
@@ -49,5 +49,19 @@ export class UsersService {
     });
 
     return true;
+  }
+
+  async banUserById(userId: number): Promise<boolean> {
+    if (!(await this.checkUserExistenceById(userId))) {
+      return false;
+    }
+
+    await this.userRepository.update({ id: userId }, { status: Status.Banned });
+    return true;
+  }
+
+  private async checkUserExistenceById(userId: number): Promise<boolean> {
+    const count = await this.userRepository.count({ id: userId });
+    return count > 0;
   }
 }


### PR DESCRIPTION
透過 `POST /users/:id/ban` 來禁用使用者

因為這與 `admin` 權限有關
所以寫了 `admin.guard.ts` 並把它拿來用
之後 `AdminGuard` 也會用到

在不同情況下的處理也完成了：
- `401 Unauthorized`
  - 未登入
- `403 Forbidden`
  - 不是 `admin`
- `400 Bad Request`
  - `id` 不是整數
- `404 Not Found`
  - 找不到目標使用者
- `201 Created`
  - 成功


