### PR TITLE
Create a route for reading a project

### DIFF
--- a/src/projects/dto/read-project.dto.ts
+++ b/src/projects/dto/read-project.dto.ts
@@ -1,0 +1,7 @@
+export class ReadProjectDto {
+  name: string;
+  createdDate: string;
+  description: string;
+  privacy: number;
+  tags: string[];
+}

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Body, Post, Delete, Request, Response, Param, UseGuards, HttpStatus, ForbiddenException, NotFoundException } from '@nestjs/common';
-import { Request as ExpressRequest, Response as ExpressResponse, response } from 'express';
+import { Controller, Body, Post, Delete, Request, Response, Param, UseGuards, HttpStatus, ForbiddenException, NotFoundException, Get } from '@nestjs/common';
+import { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import { CreateProjectDto } from './dto/create-project.dto';
+import { ReadProjectDto } from './dto/read-project.dto';
 import { ProjectsService } from './projects.service';
 import { User } from '../users/users.entity';
 import { AuthenticatedGuard } from '../common/guards/authenticated.guard';
@@ -27,6 +28,23 @@ export class ProjectsController {
       return;
     }
     response.status(HttpStatus.CONFLICT).send();
+  }
+
+  @Get(':id')
+  async readProjectById(
+    @Param('id', IdValidationPipe) projectId: number,
+    @Request() request: ExpressRequest
+  ) {
+    const user: SessionUser = request.user as SessionUser;
+    const userId: number | undefined = user && user.id;
+
+    const [result, readProjectDto] = await this.projectsService.readProjectById(projectId, userId);
+
+    if (result === OperationResult.NotFound) {
+      throw new NotFoundException();
+    }
+
+    return readProjectDto;
   }
 
   @UseGuards(AuthenticatedGuard)


### PR DESCRIPTION
`GET /api/project/:id` 先在能夠依據 id 尋找 project 並傳回資料了

對應不同種情況的邏輯也實作了：
- `400 Bad Request`
  - `id` 不是整數
- `404 Not Found`
  - 該專案不存在 或是 專案存在但該專案為 private 且使用者不是該專案之成員
- `200 OK`
  - 成功