### PR TITLE
Create a route for reading a project by its name and its owner's username

### DIFF
--- a/src/common/pipes/query-string.validation.pipe.ts
+++ b/src/common/pipes/query-string.validation.pipe.ts
@@ -1,0 +1,39 @@
+
+import { createParamDecorator, BadRequestException } from '@nestjs/common';
+import { Request } from 'express';
+
+function capitalize(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function createBadRequestException(
+  name: string,
+  code: string,
+  message: string
+): BadRequestException
+{
+  return new BadRequestException({
+    type: 'query',
+    field: [name],
+    code,
+    message,
+  })
+}
+
+function queryStringPipeHandler(name: string, request: Request) {
+  const { query } = request;
+  const value = query[name];
+
+  const isEmpty = !value || (value.constructor === String && value.length < 1);
+
+  if (isEmpty) {
+    const CODE = 'isNotEmpty';
+    const capitializedName = capitalize(name);
+    const message = `${capitializedName} is required.`;
+    throw createBadRequestException(name, CODE, message);
+  }
+
+  return value;
+}
+
+export const QueryStringPipe = createParamDecorator(queryStringPipeHandler);

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -8,6 +8,7 @@ import {
   Request,
   Response,
   Param,
+  Query,
   UseGuards,
   HttpStatus,
   ForbiddenException,
@@ -22,6 +23,7 @@ import { User } from '../users/users.entity';
 import { AuthenticatedGuard } from '../common/guards/authenticated.guard';
 import { ValidationPipe } from '../common/pipes/validation.pipe';
 import { IdValidationPipe } from '../common/pipes/id-validation.pipe';
+import { QueryStringPipe } from '../common/pipes/query-string.validation.pipe';
 import { SessionUser } from '../common/types/session-user.type';
 import { OperationResult } from '../common/types/operation-result.type';
 
@@ -43,6 +45,21 @@ export class ProjectsController {
       return;
     }
     response.status(HttpStatus.CONFLICT).send();
+  }
+
+  @Get()
+  async readProjectIdByQueries(
+    @QueryStringPipe('owner_username') ownerUsername: string,
+    @QueryStringPipe('project_name') projectName: string,
+  ) {
+    const [result, projectId] =
+      await this.projectsService.readProjectByOwnerUsernameAndProjectName(ownerUsername, projectName);
+
+    if (result === OperationResult.NotFound) {
+      throw new NotFoundException();
+    }
+
+    return projectId;
   }
 
   @Get(':id')

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -51,9 +51,19 @@ export class ProjectsController {
   async readProjectIdByQueries(
     @QueryStringPipe('owner_username') ownerUsername: string,
     @QueryStringPipe('project_name') projectName: string,
+    @Request() request: ExpressRequest,
   ) {
+    const user = request.user as SessionUser;
+    const userId = user && user.id;
+    const permission = user && user.permission;
+
     const [result, projectId] =
-      await this.projectsService.readProjectByOwnerUsernameAndProjectName(ownerUsername, projectName);
+      await this.projectsService.readProjectByOwnerUsernameAndProjectName(
+        ownerUsername,
+        projectName,
+        userId,
+        permission,
+      );
 
     if (result === OperationResult.NotFound) {
       throw new NotFoundException();

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -42,6 +42,22 @@ export class ProjectsService {
     return true;
   }
 
+  async readProjectByOwnerUsernameAndProjectName(ownerUsername: string, projectName: string): Promise<[OperationResult, number?]> {
+    const project = await this.projectRepository
+      .createQueryBuilder('project')
+      .leftJoinAndSelect('project.owner', 'owner')
+      .where('project.name = :projectName', { projectName })
+      .andWhere('owner.username = :username', { username: ownerUsername })
+      .select('project.id')
+      .getOne();
+
+    if (!project) {
+      return [OperationResult.NotFound, null];
+    }
+
+    return [OperationResult.Success, project.id];
+  }
+
   async readProjectById(projectId: number, userId?: number): Promise<[OperationResult, ReadProjectDto?]> {
     const project = await this.projectRepository.findOne(projectId, { relations: ['participants', 'tags'] });
 


### PR DESCRIPTION
實作了 `GET /api/projects?owner_username&project_name`

現在可以透過 擁有者名稱 與 專案名稱 來存取指定 project 的 `id` 了

同時也對以下情況進行實作：
- `400 Bad Request`
  - 可能為以下情況一或多種情況造成
    - `owner_username` 為空字串
    - `project_name` 為空字串
- `404 Not Found`
  - 無論權限，專案實際不存在
  - 當專案存在時，根據專案隱私性與使用者權限處理
    - 若專案的 `privacy` 為 public
      - 所有使用者皆看得到
    - 若專案的 `privacy` 為 private
      - 使用者尚未登入 或 沒參與該專案
      - （反之，參與專案者 或 管理員 就可以看到該專案）
- `200 OK`
  - 成功