### PR TITLE
Create a route for transfering a project to other member in this project

### DIFF
--- a/src/common/types/resource.type.ts
+++ b/src/common/types/resource.type.ts
@@ -1,0 +1,7 @@
+export enum Resource {
+  User = 0,
+  Project,
+  Issue,
+  Comment,
+  Label
+}

--- a/src/projects/dto/transfer-project.dto.ts
+++ b/src/projects/dto/transfer-project.dto.ts
@@ -1,0 +1,11 @@
+import { IsInt, IsPositive } from 'class-validator';
+
+export class TransferProjectDto {
+  @IsInt({
+    message: 'Id must be an integer.'
+  })
+  @IsPositive({
+    message: 'The number of id must be positive.'
+  })
+  readonly id: number;
+}

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -18,6 +18,7 @@ import {
 import { Request as ExpressRequest, Response as ExpressResponse } from 'express';
 import { CreateProjectDto } from './dto/create-project.dto';
 import { UpdateProjectDto } from './dto/update-project.dto';
+import { TransferProjectDto } from './dto/transfer-project.dto';
 import { ProjectsService } from './projects.service';
 import { User, Permission } from '../users/users.entity';
 import { AuthenticatedGuard } from '../common/guards/authenticated.guard';
@@ -106,6 +107,14 @@ export class ProjectsController {
       case OperationResult.Forbidden: throw new ForbiddenException();
       case OperationResult.Conflict: throw new ConflictException();
     }
+  }
+
+  @UseGuards(AuthenticatedGuard)
+  @Put(':id/owner')
+  async transferProject(
+    @Param('id', IdValidationPipe) projectId: number,
+    @Body(ValidationPipe) body: TransferProjectDto
+  ) {
   }
 
   @UseGuards(AuthenticatedGuard)

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -124,8 +124,6 @@ export class ProjectsController {
       ownerId,
       permission,
     );
-
-    console.log(result);
   }
 
   @UseGuards(AuthenticatedGuard)

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -113,8 +113,19 @@ export class ProjectsController {
   @Put(':id/owner')
   async transferProject(
     @Param('id', IdValidationPipe) projectId: number,
-    @Body(ValidationPipe) body: TransferProjectDto
+    @Body(ValidationPipe) body: TransferProjectDto,
+    @Request() request: ExpressRequest,
   ) {
+    const { id: ownerId, permission } = request.user as SessionUser;
+    const { id: targetUserId } = body;
+    const result = await this.projectsService.transferProject(
+      projectId,
+      targetUserId,
+      ownerId,
+      permission,
+    );
+
+    console.log(result);
   }
 
   @UseGuards(AuthenticatedGuard)

--- a/src/projects/projects.module.ts
+++ b/src/projects/projects.module.ts
@@ -4,9 +4,10 @@ import { Project } from './projects.entity';
 import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
 import { TagsModule } from '../tags/tags.module';
+import { UsersModule } from '../users/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Project]), TagsModule],
+  imports: [TypeOrmModule.forFeature([Project]), UsersModule, TagsModule],
   controllers: [ProjectsController],
   providers: [ProjectsService],
 })

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -231,18 +231,18 @@ export class ProjectsService {
     // The user is not the project owner nor an admin.
     const isOwner = project.ownerId === ownerId;
     if (!isOwner && !isAdmin) {
-      return [OperationResult.Forbidden, Resource.User, REASON_USER_NOT_OWNER]; // OK
+      return [OperationResult.Forbidden, Resource.User, REASON_USER_NOT_OWNER];
     }
 
     // Get the target user.
     const targetUser = await this.userService.findOne(targetUserId);
     if (!targetUser) {
-      return [OperationResult.NotFound, Resource.User]; // OK
+      return [OperationResult.NotFound, Resource.User];
     }
 
     // Cannot transfer the project to the target user who is banned.
     if (targetUser.status === UserStatue.Banned) {
-      return [OperationResult.Forbidden, Resource.User, REASON_TARGET_USER_BANNED]; // OK
+      return [OperationResult.Forbidden, Resource.User, REASON_TARGET_USER_BANNED];
     }
 
     // Search for the target user in the project.
@@ -255,7 +255,7 @@ export class ProjectsService {
 
     // Cannot transfer the project to the target user who is not a member in this project.
     if (count < 1) {
-      return [OperationResult.Forbidden, Resource.User, REASON_TARGET_USER_NOT_PARTICIPANT]; // OK
+      return [OperationResult.Forbidden, Resource.User, REASON_TARGET_USER_NOT_PARTICIPANT];
     }
 
     // Check whether the target user has a project whose name is the same as this project's.
@@ -270,6 +270,9 @@ export class ProjectsService {
     if (count > 0) {
       return [OperationResult.Conflict, Resource.User];
     }
+
+    // Finnaly, transfer the project to the target users.
+    await this.projectRepository.update({ id: projectId }, { owner: { id: targetUserId } });
 
     return [OperationResult.Success, Resource.Project];
   }


### PR DESCRIPTION
實作 `PUT /api/projects/:id/owner`
專案擁有者可以將他的專案轉移給在這專案下的另一位沒有被封鎖的成員
管理員可以轉移任意專案

處理了以下 11 種情況：
- `401 Unauthorized`
    - 使用者沒有登入
- `400 Bad Request`
    - `id` 不為整數
    - `body` 內的轉移對象 `id` 不為整數
- `404 Not Found` （專案）
    - 專案實際上不存在
    - 專案存在，但使用者不是專案成員或管理員
    - 被轉移者不存在
- `403 Forbidden`
    - 使用者不為 專案擁有者 或是 管理員
    - 被轉移者為被封鎖狀態（Banned）
    - 被轉移者不為此專案的成員
- `404 Not Found` （使用者）
    - 被轉移者不存在
- `409 Conflict`
    - 被轉移者目前所擁有的專案之中，有一個專案的名稱與此專案一樣
- `200 OK`
    - 成功