### PR TITLE
Create a route for changing a project's privacy

### DIFF
--- a/src/projects/dto/privacy-project.dto.ts
+++ b/src/projects/dto/privacy-project.dto.ts
@@ -1,0 +1,9 @@
+import { IsEnum } from 'class-validator';
+import { Privacy } from '../projects.entity';
+
+export class PrivacyProjectDto {
+  @IsEnum(Privacy, {
+    message: 'The value of privacy is invalid.'
+  })
+  privacy: Privacy;
+}

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -19,6 +19,7 @@ import { Request as ExpressRequest, Response as ExpressResponse } from 'express'
 import { CreateProjectDto } from './dto/create-project.dto';
 import { UpdateProjectDto } from './dto/update-project.dto';
 import { TransferProjectDto } from './dto/transfer-project.dto';
+import { PrivacyProjectDto } from './dto/privacy-project.dto';
 import { ProjectsService } from './projects.service';
 import { User, Permission } from '../users/users.entity';
 import { AuthenticatedGuard } from '../common/guards/authenticated.guard';
@@ -149,6 +150,28 @@ export class ProjectsController {
       throw new ConflictException({
         message: "Cannot transfer the project to the target user who has a project whose name is the same as this project's."
       });
+    }
+  }
+
+  @UseGuards(AuthenticatedGuard)
+  @Put(':id/privacy')
+  async changePrivacy(
+    @Param('id', IdValidationPipe) projectId: number,
+    @Body(ValidationPipe) privacyProjectDto: PrivacyProjectDto,
+    @Request() request: ExpressRequest,
+  ) {
+    const { id: userId, permission } = request.user as SessionUser;
+    const { privacy } = privacyProjectDto;
+    const result = await this.projectsService.changePrivacy(
+      projectId,
+      privacy,
+      userId,
+      permission,
+    );
+
+    switch (result) {
+      case OperationResult.NotFound: throw new NotFoundException();
+      case OperationResult.Forbidden: throw new ForbiddenException();
     }
   }
 

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -277,6 +277,29 @@ export class ProjectsService {
     return [OperationResult.Success, Resource.Project];
   }
 
+  async changePrivacy(
+    projectId: number,
+    privacy: Privacy,
+    userId: number,
+    permission: number
+  ): Promise<OperationResult>
+  {
+    const project = await this.projectRepository.findOne(projectId, { relations: ['owner'] });
+    if (!project) {
+      return OperationResult.NotFound;
+    }
+
+    const isOwner = project.owner.id === userId;
+    const isAdmin = permission === Permission.Admin;
+    if (!isOwner && !isAdmin) {
+      return OperationResult.Forbidden;
+    }
+
+    await this.projectRepository.update({ id: projectId }, { privacy });
+
+    return OperationResult.Success;
+  }
+
   async deleteProjectById(projectId: number, userId: number, permission: Permission): Promise<OperationResult> {
     const project = await this.projectRepository.findOne(projectId, { select: ['id', 'owner'], relations: ['owner'] });
 


### PR DESCRIPTION
實作 `PUT /api/projects/:id/privacy`
專案擁有者 能透透過 `id` 與 `body` 裡面的 `privacy` 來指定其擁有專案的隱私性
管理員能夠更改任意專的隱私性

此路由有以下幾種情況：
- `401 Unauthorized`
  - 使用者尚未登入
- `400 Bad Request`
  - `id` 不為整數
  - `privacy` 不為數值 0 或 1
- `404 Not Found`
  - 該專案不存在
- `403 Forbidden`
  - 非專案擁有者 或是 管理員身份
- `200 OK`
  - 成功