### PR TITLE
Create a route for reading all member from a project

### DIFF
--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -176,6 +176,29 @@ export class ProjectsController {
     }
   }
 
+  @Get(':id/members')
+  async readMembersOfProject(
+    @Param('id', IdValidationPipe) projectId: number,
+    @Request() request: ExpressRequest,
+  ) {
+    const user: SessionUser | undefined = request.user as SessionUser;
+    const userId: number | undefined = user && user.id;
+    const permission: Permission | undefined = user && user.permission;
+    const [result, memberIds] = await this.projectsService.readMembersOfProject(
+      projectId,
+      userId,
+      permission,
+    );
+
+    if (result === OperationResult.NotFound) {
+      throw new NotFoundException({
+        message: 'The project does not exist',
+      });
+    }
+
+    return { members: memberIds };
+  }
+
   @UseGuards(AuthenticatedGuard)
   @Post(':id/members')
   async addUserToProject(


### PR DESCRIPTION
實作 `GET /api/projects/:id/members`

依據使用者身份，使用者能夠取得指定專案下的所有使用者 `id`
管理員能夠取得任意專案下的所有使用者 `id`

此路由處理了以下不同情況：
- `400 Bad Request`
  - `id` 不為整數
- `404 Not Found`
  - 指定專案不存在
  - 使用者不為 該專案之專案成員 或是 管理員
- `200 OK`
  - 成功

```jsonld
{
  "members": number[]
}
```