### PR TITLE
Create a new entity Label

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,11 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './users/users.entity';
 import { Project } from './projects/projects.entity';
 import { Tag } from './tags/tags.entity';
+import { Label } from './labels/labels.entity';
 import { UsersModule } from './users/users.module';
 import { ProjectsModule } from './projects/projects.module';
 import { TagsModule } from './tags/tags.module';
 import { AuthModule } from './auth/auth.module';
 import { SessionModule } from './session/session.module';
+import { LabelsModule } from './labels/labels.module';
 
 const {
   DB_HOST,
@@ -25,7 +27,7 @@ const {
       username: DB_USERNAME,
       password: DB_PASSWORD,
       database: DB_DATABASE,
-      entities: [User, Project, Tag],
+      entities: [User, Project, Tag, Label],
       synchronize: true,
     }),
     UsersModule,
@@ -33,6 +35,7 @@ const {
     TagsModule,
     AuthModule,
     SessionModule,
+    LabelsModule,
   ],
 })
 export class AppModule {}

--- a/src/labels/labels.entity.ts
+++ b/src/labels/labels.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { Project } from '../projects/projects.entity';
+
+@Entity()
+export class Label {
+  @PrimaryGeneratedColumn()
+  id: number
+
+  @Column({ length: 50 })
+  name: string
+
+  @Column({ length: 250 })
+  description: string
+
+  @Column({ length: 6 })
+  color: string
+
+  @Column({ default: false })
+  deprecated: boolean
+
+  @ManyToOne(_ => Project, project => project.labels, { cascade: ['remove'], nullable: false })
+  project: Project
+};

--- a/src/labels/labels.module.ts
+++ b/src/labels/labels.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Label } from './labels.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Label])],
+})
+export class LabelsModule {}

--- a/src/projects/projects.entity.ts
+++ b/src/projects/projects.entity.ts
@@ -1,6 +1,7 @@
 import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, OneToMany, ManyToMany } from 'typeorm';
 import { User } from '../users/users.entity';
 import { Tag } from '../tags/tags.entity';
+import { Label } from '../labels/labels.entity';
 
 export enum Privacy {
   Public = 0,
@@ -40,4 +41,7 @@ export class Project {
 
   @ManyToMany(_ => User, user => user.participatingProjects)
   participants: User[];
+
+  @OneToMany(_ => Label, label => label.project)
+  labels: Label[];
 }


### PR DESCRIPTION
建立了新的資料庫表格 `label`
其用於存放所有 Project 的 Label

對應至 ER Diagram 上的欄位：
- `id` 主鍵、整數，自動生成
- `name` 字串，長度 50
  - Label 的名稱
- `description` 字串，長度 250
  - Label 的敘述
- `color` 字串，長度 6
  - Label 的顏色
- `deprecated` 布林，預設為 `false`
  - Label 是否被棄用
