### PR TITLE
Create a route for adding a new label for a project

### DIFF
--- a/src/labels/dto/create-label.dto.ts
+++ b/src/labels/dto/create-label.dto.ts
@@ -1,0 +1,6 @@
+export class CreateLabelDto {
+  readonly name: string;
+  readonly description: string;
+  readonly color: string;
+  readonly projectId: number;
+}

--- a/src/labels/labels.module.ts
+++ b/src/labels/labels.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Label } from './labels.entity';
+import { LabelsService } from './labels.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Label])],
+  providers: [LabelsService],
+  exports: [LabelsService],
 })
 export class LabelsModule {}

--- a/src/labels/labels.service.spec.ts
+++ b/src/labels/labels.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LabelsService } from './labels.service';
+
+describe('LabelsService', () => {
+  let service: LabelsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LabelsService],
+    }).compile();
+
+    service = module.get<LabelsService>(LabelsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/labels/labels.service.ts
+++ b/src/labels/labels.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Label } from './labels.entity';
+import { CreateLabelDto } from './dto/create-label.dto';
+import { OperationResult } from '../common/types/operation-result.type';
+
+@Injectable()
+export class LabelsService {
+  constructor(
+    @InjectRepository(Label)
+    private readonly labelRepository: Repository<Label>
+  ) {}
+
+  async create(createLabelDto: CreateLabelDto) {
+    const label = await this.labelRepository.findOne({
+      name: createLabelDto.name,
+    });
+
+    if (label) {
+      const { deprecated } = label;
+      if (!deprecated) {
+        return OperationResult.Conflict;
+      }
+
+      await this.reuseDeprecatedLabel(label, createLabelDto);
+    }
+    else {
+      await this.createNewLabel(createLabelDto);
+    }
+
+    return OperationResult.Success;
+  }
+
+  private async reuseDeprecatedLabel(label: Label, createLabelDto: CreateLabelDto) {
+    label.name = createLabelDto.name;
+    label.description = createLabelDto.description;
+    label.color = createLabelDto.color;
+    label.deprecated = false;
+    await this.labelRepository.save(label);
+  }
+
+  private async createNewLabel(createLabelDto: CreateLabelDto) {
+    const label = this.labelRepository.create({
+      name: createLabelDto.name,
+      description: createLabelDto.description,
+      color: createLabelDto.color,
+      project: { id: createLabelDto.projectId },
+    });
+    await this.labelRepository.save(label);
+  }
+}

--- a/src/projects/dto/labels/create-label.dto.ts
+++ b/src/projects/dto/labels/create-label.dto.ts
@@ -1,0 +1,27 @@
+import { IsNotEmpty, MaxLength, Length } from 'class-validator';
+
+export class CreateLabelDto {
+  @IsNotEmpty({
+    message: 'Name is required.'
+  })
+  @MaxLength(50, {
+    message: 'The length of name must be less than or equal to 50.'
+  })
+  readonly name: string;
+
+  @IsNotEmpty({
+    message: 'Description is required.'
+  })
+  @MaxLength(250, {
+    message: 'The length of description must be less than or equal to 250'
+  })
+  readonly description: string;
+
+  @IsNotEmpty({
+    message: 'Color is required.'
+  })
+  @Length(6, 6, {
+    message: 'The length of color must be 6.'
+  })
+  readonly color: string;
+}

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -21,6 +21,7 @@ import { UpdateProjectDto } from './dto/update-project.dto';
 import { TransferProjectDto } from './dto/transfer-project.dto';
 import { PrivacyProjectDto } from './dto/privacy-project.dto';
 import { MemberIdDto } from './dto/member-id.dto';
+import { CreateLabelDto } from './dto/labels/create-label.dto';
 import { ProjectsService } from './projects.service';
 import { User, Permission } from '../users/users.entity';
 import { AuthenticatedGuard } from '../common/guards/authenticated.guard';
@@ -311,5 +312,14 @@ export class ProjectsController {
     }
 
     response.status(HttpStatus.NO_CONTENT).send();
+  }
+
+  @UseGuards(AuthenticatedGuard)
+  @Post(':id/labels')
+  async addNewLabelToProject(
+    @Param('id', IdValidationPipe) projectId: number,
+    @Body(ValidationPipe) createLabelDto: CreateLabelDto,
+    @Request() request: ExpressRequest,
+  ) {
   }
 }

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -321,5 +321,27 @@ export class ProjectsController {
     @Body(ValidationPipe) createLabelDto: CreateLabelDto,
     @Request() request: ExpressRequest,
   ) {
+    const { id: userId, permission } = request.user as SessionUser;
+    const result = await this.projectsService.addNewLabel(
+      projectId,
+      createLabelDto,
+      userId,
+      permission
+    );
+
+    switch (result) {
+      case OperationResult.NotFound:
+        throw new NotFoundException({
+          message: 'The project does not exist.',
+        });
+      case OperationResult.Forbidden:
+        throw new ForbiddenException({
+          message: 'Cannot add the new label since you are not the owner of this project.',
+        });
+      case OperationResult.Conflict:
+        throw new ConflictException({
+          message: 'Cannot add the new label since there is another label having the same name.'
+        });
+    }
   }
 }

--- a/src/projects/projects.module.ts
+++ b/src/projects/projects.module.ts
@@ -5,9 +5,15 @@ import { ProjectsController } from './projects.controller';
 import { ProjectsService } from './projects.service';
 import { TagsModule } from '../tags/tags.module';
 import { UsersModule } from '../users/users.module';
+import { LabelsModule } from '../labels/labels.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Project]), UsersModule, TagsModule],
+  imports: [
+    TypeOrmModule.forFeature([Project]),
+    UsersModule,
+    TagsModule,
+    LabelsModule,
+  ],
   controllers: [ProjectsController],
   providers: [ProjectsService],
 })


### PR DESCRIPTION
實作 `POST /api/projects/:id/labels`

專案擁有者可以新增 Label 到專案上
管理員可以對任意專案新增 Label

此路由處理以下情況：
- `401 Unauthorized`
    - 使用者尚未登入
- `400 Bad Request`
    - `id` 不為整數
    - `name` 字串長度超過 50
    - `description` 字串長度超過 250
    - `color` 字串長度不為 6
- `404 Not Found`
    - 該專案不存在
- `403 Forbidden`
    - 使用者不為 專案擁有者 或是 管理員
- `409 Conflict`
    - 已存在名稱相同的 Label
- `201 Created`
    - 成功
