### PR TITLE
Create a route for reading all labels of a project

### DIFF
--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -314,6 +314,29 @@ export class ProjectsController {
     response.status(HttpStatus.NO_CONTENT).send();
   }
 
+  @Get(':id/labels')
+  async readAllLabelsOfProject(
+    @Param('id', IdValidationPipe) projectId: number,
+    @Request() request: ExpressRequest,
+  ) {
+    const user = request.user as SessionUser;
+    const userId: number | undefined = user && user.id;
+    const permission: Permission | undefined = user && user.permission;
+    const [result, labelIds] = await this.projectsService.readAllLabelIds(
+      projectId,
+      userId,
+      permission,
+    );
+
+    if (result === OperationResult.NotFound) {
+      throw new NotFoundException({
+        message: 'The project does not exist.',
+      });
+    }
+
+    return { labels: labelIds };
+  }
+
   @UseGuards(AuthenticatedGuard)
   @Post(':id/labels')
   async addNewLabelToProject(

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -453,4 +453,29 @@ export class ProjectsService {
       projectId
     });
   }
+
+  async readAllLabelIds(
+    projectId: number,
+    userId?: number,
+    permission?: Permission,
+  ): Promise<[OperationResult, number[]?]>
+  {
+    const project = await this.projectRepository.findOne(projectId, {
+      relations: ['participants', 'labels'],
+    });
+
+    if (!project) {
+      return [OperationResult.NotFound, null];
+    }
+
+    const isPrivate = project.privacy === Privacy.Private;
+    const isParticipant = userId && project.participants.some(user => user.id === userId);
+    const isAdmin = permission && permission === Permission.Admin;
+    if (isPrivate && !isParticipant && !isAdmin) {
+      return [OperationResult.NotFound, null];
+    }
+
+    const labelIds = project.labels.map(label => label.id);
+    return [OperationResult.Success, labelIds];
+  }
 }


### PR DESCRIPTION
實作 `GET /api/projects/:id/labels`
使用者能夠取得指定專案上的 Label
若並非 專案參與者 或是 管理員，則使用者看不到該專案的 Label

此路由處理了以下情況：
- `400 Bad Request`
    - `id` 不為整數
- `404 Not Found`
    - 目標專案不存在
    - 專案存在，但專案的 `privacy` 為 `private` 且使用者不為專案成員或是管理員
- `200 OK`
    - 成功
```jsonld
{
    "labels": number[]
}
```