### PR TITLE
Create a route for reading a label by its id

### DIFF
--- a/src/labels/dto/read-label.dto.ts
+++ b/src/labels/dto/read-label.dto.ts
@@ -1,0 +1,6 @@
+export class ReadLabelDto {
+  readonly name: string;
+  readonly description: string;
+  readonly color: string;
+  readonly deprecated: boolean;
+}

--- a/src/labels/labels.controller.spec.ts
+++ b/src/labels/labels.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LabelsController } from './labels.controller';
+
+describe('Labels Controller', () => {
+  let controller: LabelsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LabelsController],
+    }).compile();
+
+    controller = module.get<LabelsController>(LabelsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/labels/labels.controller.ts
+++ b/src/labels/labels.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Param, NotFoundException } from '@nestjs/common';
+import { LabelsService } from './labels.service';
+import { IdValidationPipe } from '../common/pipes/id-validation.pipe';
+import { OperationResult } from '../common/types/operation-result.type';
+
+@Controller('labels')
+export class LabelsController {
+  constructor(
+    private readonly labelsService: LabelsService,
+  ) { }
+
+  @Get(':id')
+  async readLabelById(
+    @Param('id', IdValidationPipe) labelId: number,
+  ) {
+    const [result, label] = await this.labelsService.readOneById(labelId);
+    if (result === OperationResult.NotFound) {
+      throw new NotFoundException({
+        message: 'The label does not exist.',
+      });
+    }
+
+    return label;
+  }
+}

--- a/src/labels/labels.module.ts
+++ b/src/labels/labels.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Label } from './labels.entity';
 import { LabelsService } from './labels.service';
+import { LabelsController } from './labels.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Label])],
   providers: [LabelsService],
   exports: [LabelsService],
+  controllers: [LabelsController],
 })
 export class LabelsModule {}

--- a/src/labels/labels.service.ts
+++ b/src/labels/labels.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Label } from './labels.entity';
 import { CreateLabelDto } from './dto/create-label.dto';
+import { ReadLabelDto } from './dto/read-label.dto';
 import { OperationResult } from '../common/types/operation-result.type';
 
 @Injectable()
@@ -49,5 +50,20 @@ export class LabelsService {
       project: { id: createLabelDto.projectId },
     });
     await this.labelRepository.save(label);
+  }
+
+  async readOneById(labelId: number): Promise<[OperationResult, ReadLabelDto?]> {
+    const label = await this.labelRepository.findOne(labelId);
+    if (!label) {
+      return [OperationResult.NotFound, null];
+    }
+
+    const readLabelDto: ReadLabelDto = {
+      name: label.name,
+      description: label.description,
+      color: label.color,
+      deprecated: label.deprecated,
+    };
+    return [OperationResult.Success, readLabelDto];
   }
 }


### PR DESCRIPTION
實作 `GET /api/labels/:id`
使用者能夠透過 Label 的 Id 來取得指定的 Label 資料

此路由有以下幾種狀態：
- `400 Bad Request`
    - `id` 不為整數
- `404 Not Found`
    - 該 Label 不存在
- `200 OK`
    - 成功
```jsonld
{
    "name": string,
    "description": string,
    "color": string,
    "deprecated": boolean
}
```