### PR TITLE
Create a route for updating a label by its id

### DIFF
--- a/src/labels/dto/update-label.dto.ts
+++ b/src/labels/dto/update-label.dto.ts
@@ -1,0 +1,27 @@
+import { IsNotEmpty, MaxLength, Length } from 'class-validator';
+
+export class UpdateLabelDto {
+  @IsNotEmpty({
+    message: 'Name is required.'
+  })
+  @MaxLength(50, {
+    message: 'The length of name must be less than or equal to 50.'
+  })
+  readonly name: string;
+
+  @IsNotEmpty({
+    message: 'Description is required.'
+  })
+  @MaxLength(250, {
+    message: 'The length of description must be less than or equal to 250'
+  })
+  readonly description: string;
+
+  @IsNotEmpty({
+    message: 'Color is required.'
+  })
+  @Length(6, 6, {
+    message: 'The length of color must be 6.'
+  })
+  readonly color: string;
+}

--- a/src/labels/labels.controller.ts
+++ b/src/labels/labels.controller.ts
@@ -1,7 +1,21 @@
-import { Controller, Get, Param, NotFoundException } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Put,
+  Param,
+  Body,
+  Request,
+  UseGuards,
+  NotFoundException
+} from '@nestjs/common';
+import { Request as ExpressRequest } from 'express';
 import { LabelsService } from './labels.service';
+import { UpdateLabelDto } from './dto/update-label.dto';
+import { AuthenticatedGuard } from '../common/guards/authenticated.guard';
+import { ValidationPipe } from '../common/pipes/validation.pipe';
 import { IdValidationPipe } from '../common/pipes/id-validation.pipe';
 import { OperationResult } from '../common/types/operation-result.type';
+import { SessionUser } from '../common/types/session-user.type';
 
 @Controller('labels')
 export class LabelsController {
@@ -21,5 +35,14 @@ export class LabelsController {
     }
 
     return label;
+  }
+
+  @UseGuards(AuthenticatedGuard)
+  @Put(':id')
+  async updateLabelById(
+    @Param('id', IdValidationPipe) labelId: number,
+    @Body(ValidationPipe) updateLabelDto: UpdateLabelDto,
+    @Request() request: ExpressRequest,
+  ) {
   }
 }

--- a/src/labels/labels.module.ts
+++ b/src/labels/labels.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Label } from './labels.entity';
 import { LabelsService } from './labels.service';
 import { LabelsController } from './labels.controller';
+import { ProjectsModule } from '../projects/projects.module';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Label])],

--- a/src/projects/projects.module.ts
+++ b/src/projects/projects.module.ts
@@ -16,5 +16,6 @@ import { LabelsModule } from '../labels/labels.module';
   ],
   controllers: [ProjectsController],
   providers: [ProjectsService],
+  exports: [ProjectsService],
 })
 export class ProjectsModule {}


### PR DESCRIPTION
實作 `PUT /api/labels/:id`

使用者能夠透過 `id` 來將指定的 Label 更新
若使用者不是 專案擁有者 或是 管理員，則其無法進行此操作

此路由處理了以下幾種情況：
- `401 Unauthorized`
    - 使用者尚未登入
- `400 Bad Request`
    - `id` 不為整數
    - `name` 字串長度超過 50
    - `description` 字串長度超過 250
    - `color` 字串長度不為 6
- `404 Not Found`
    - 該 Label 不存在
- `403 Forbidden`
    - 使用者不為 專案擁有者 或是 管理員
- `409 Conflict`
    - 在目前專案下的所有 Label 中存在 `name` 與更新內容的 `name` 相同的值
- `200 OK`
    - 成功