### PR TITLE
Create a route for removing a label by its id

### DIFF
--- a/src/labels/labels.controller.ts
+++ b/src/labels/labels.controller.ts
@@ -2,9 +2,12 @@ import {
   Controller,
   Get,
   Put,
+  Delete,
   Param,
   Body,
   Request,
+  HttpCode,
+  HttpStatus,
   UseGuards,
   NotFoundException,
   ForbiddenException,
@@ -66,6 +69,32 @@ export class LabelsController {
       case OperationResult.Conflict:
         throw new ConflictException({
           message: 'Cannot update the label since there is another label having the same name.',
+        });
+    }
+  }
+
+  @UseGuards(AuthenticatedGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Delete(':id')
+  async removeLabelById(
+    @Param('id', IdValidationPipe) labelId: number,
+    @Request() request: ExpressRequest,
+  ) {
+    const { id: userId, permission } = request.user as SessionUser;
+    const result = await this.labelsService.removeOneById(
+      labelId,
+      userId,
+      permission,
+    );
+
+    switch (result) {
+      case OperationResult.NotFound:
+        throw new NotFoundException({
+          message: 'The label does not exist.',
+        });
+      case OperationResult.Forbidden:
+        throw new ForbiddenException({
+          message: 'Cannot remove the label since you are not the owner of this project.',
         });
     }
   }


### PR DESCRIPTION
實作 `DELETE - /api/labels/:id`

使用者能夠透過 `id` 將指定的 Label 自專案中移除
若使用者不是 在該 Label 所屬專案之下的專案擁有者 或是 管理元
則無法進行此動作

此路由處理了以下幾種情況：
- `401 Unauthorized`
    - 使用者未登入
- `400 Bad Request`
    - `id` 不為整數
- `404 Not Found`
    - 該 Label 不存在
- `403 Forbidden`
    - 使用者不為在 Label 所屬的專案之下的 專案擁有者 或是 管理員
- `204 No Content`
    - 成功
