### PR TITLE
Create a route for creating a new issue of a project

### DIFF
--- a/src/comments/comments.entity.ts
+++ b/src/comments/comments.entity.ts
@@ -24,7 +24,7 @@ export class Comment {
   @Column()
   content: string;
 
-  @Column()
+  @Column({ default: Status.Normal })
   status: Status;
 
   @CreateDateColumn()

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Comment } from './comments.entity';
+import { CommentsService } from './comments.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Comment])],
+  providers: [CommentsService],
+  exports: [CommentsService],
 })
 export class CommentsModule {}

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentsService } from './comments.service';
+
+describe('CommentsService', () => {
+  let service: CommentsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CommentsService],
+    }).compile();
+
+    service = module.get<CommentsService>(CommentsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Comment } from './comments.entity';
+import { CreateCommentDto } from './dto/create-comment.dto';
+
+@Injectable()
+export class CommentsService {
+  constructor(
+    @InjectRepository(Comment)
+    private readonly commentRepository: Repository<Comment>,
+  ) { }
+
+  async create(createCommentDto: CreateCommentDto) {
+    const comment = this.commentRepository.create({
+      content: createCommentDto.content,
+      owner: { id: createCommentDto.ownerId },
+      issue: { id: createCommentDto.issueId },
+    });
+
+    await this.commentRepository.save(comment);
+  }
+}

--- a/src/comments/dto/create-comment.dto.ts
+++ b/src/comments/dto/create-comment.dto.ts
@@ -1,0 +1,5 @@
+export class CreateCommentDto {
+  readonly ownerId: number;
+  readonly content: string;
+  readonly issueId: number;
+}

--- a/src/common/util/error-record-generator.ts
+++ b/src/common/util/error-record-generator.ts
@@ -19,23 +19,26 @@ export function createGenerator(type: string) {
     // Record each error
     errors.forEach((error) => {
       // Get all errors' name
-      const constraintNames = Object.keys(error.constraints);
+      const { constraints } = error;
+      const constraintNames = constraints && Object.keys(constraints);
   
       // Memorize error path
       const currentField = [...field, error.property];
 
-      const records: ErrorRecord[] = constraintNames.map((name) => ({
-        type,
-        field: currentField,
-        code: name,
-        message: error.constraints[name],
-      }));
+      if (constraintNames) {
+        const records: ErrorRecord[] = constraintNames.map((name) => ({
+          type,
+          field: currentField,
+          code: name,
+          message: error.constraints[name],
+        }));
 
-      results.push(...records);
+        results.push(...records);
+      }
   
       // If there is any inner error, then go down and record them.
       if (error.children.length > 0) {
-        generate(error.children, field);
+        generate(error.children, currentField);
       }
     });
 

--- a/src/common/util/error-record-generator.ts
+++ b/src/common/util/error-record-generator.ts
@@ -18,27 +18,31 @@ export function createGenerator(type: string) {
   function generate(errors: ValidationError[], field: string[] = []): ErrorRecord[] {
     // Record each error
     errors.forEach((error) => {
+      const { constraints, children, property } = error;
+
       // Get all errors' name
-      const { constraints } = error;
       const constraintNames = constraints && Object.keys(constraints);
   
       // Memorize error path
-      const currentField = [...field, error.property];
+      let currentField = field;
+      if (field[field.length - 1] !== property) { // Escapse nested duplications.
+        currentField = [...field, property];
+      }
 
       if (constraintNames) {
         const records: ErrorRecord[] = constraintNames.map((name) => ({
           type,
           field: currentField,
           code: name,
-          message: error.constraints[name],
+          message: constraints[name],
         }));
 
         results.push(...records);
       }
   
       // If there is any inner error, then go down and record them.
-      if (error.children.length > 0) {
-        generate(error.children, currentField);
+      if (children && children.length > 0) {
+        generate(children, currentField);
       }
     });
 

--- a/src/issues/dto/create-issue.dto.ts
+++ b/src/issues/dto/create-issue.dto.ts
@@ -1,0 +1,12 @@
+class CommentDto {
+  readonly content: string;
+}
+
+export class CreateIssueDto {
+  readonly title: string;
+  readonly comment: CommentDto;
+  readonly projectId: number;
+  readonly ownerId: number;
+  readonly labelIds: number[];
+  readonly assigneeIds: number[];
+}

--- a/src/issues/issues.entity.ts
+++ b/src/issues/issues.entity.ts
@@ -32,7 +32,7 @@ export class Issue {
   @Column()
   title: string;
 
-  @Column()
+  @Column({ default: Status.Open })
   status: string;
 
   @CreateDateColumn()

--- a/src/issues/issues.module.ts
+++ b/src/issues/issues.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Issue } from './issues.entity';
+import { IssuesService } from './issues.service';
+import { CommentsModule } from '../comments/comments.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Issue])],
+  imports: [TypeOrmModule.forFeature([Issue]), CommentsModule],
+  providers: [IssuesService],
+  exports: [IssuesService],
 })
 export class IssuesModule {}

--- a/src/issues/issues.service.spec.ts
+++ b/src/issues/issues.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { IssuesService } from './issues.service';
+
+describe('IssuesService', () => {
+  let service: IssuesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [IssuesService],
+    }).compile();
+
+    service = module.get<IssuesService>(IssuesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/issues/issues.service.ts
+++ b/src/issues/issues.service.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Issue } from './issues.entity'
+import { CreateIssueDto } from './dto/create-issue.dto';
+import { CommentsService } from '../comments/comments.service';
+import { CreateCommentDto } from '../comments/dto/create-comment.dto';
+
+function wrapIdsIntoObjects(ids: number[]) {
+  return ids.map(id => ({ id }));
+}
+
+@Injectable()
+export class IssuesService {
+  constructor(
+    @InjectRepository(Issue)
+    private readonly issueRepository: Repository<Issue>,
+    private readonly commentsService: CommentsService,
+  ) { }
+
+  async create(createIssueDto: CreateIssueDto) {
+    // Calculate the next issue number.
+    const count = await this.issueRepository.count({
+      where: {
+        project: { id: createIssueDto.projectId },
+      },
+    });
+    const issueNumber = count + 1;
+
+    // Transform labels and participants.
+    const labelRelationIds = wrapIdsIntoObjects(createIssueDto.labelIds);
+    const participantRelationIds = wrapIdsIntoObjects(createIssueDto.assigneeIds);
+
+    // Create the new issue.
+    let issue = this.issueRepository.create({
+      number: issueNumber,
+      title: createIssueDto.title,
+      project: { id: createIssueDto.projectId },
+      owner: { id: createIssueDto.ownerId },
+      labels: labelRelationIds,
+      assignees: participantRelationIds,
+    });
+    issue = await this.issueRepository.save(issue);
+
+    // Create the first new comment.
+    // Here use the issue id, so the issue need to be created first.
+    const createCommentDto: CreateCommentDto = {
+      ownerId: createIssueDto.ownerId,
+      content: createIssueDto.comment.content,
+      issueId: issue.id,
+    };
+    await this.commentsService.create(createCommentDto);
+  }
+}

--- a/src/labels/labels.service.ts
+++ b/src/labels/labels.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, Inject, forwardRef } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Not } from 'typeorm';
+import { Repository, Not, In } from 'typeorm';
 import { Label } from './labels.entity';
 import { CreateLabelDto } from './dto/create-label.dto';
 import { ReadLabelDto } from './dto/read-label.dto';
@@ -138,5 +138,20 @@ export class LabelsService {
 
     await this.labelRepository.remove(label);
     return OperationResult.Success;
+  }
+
+  async checkLabelsExistenceOfProject(
+    labelIds: number[],
+    projectId: number,
+  ): Promise<boolean>
+  {
+    const count = await this.labelRepository.count({
+      where: {
+        id: In(labelIds),
+        project: { id: projectId },
+      },
+    });
+
+    return count === labelIds.length;
   }
 }

--- a/src/projects/dto/issues/create-issue.dto.ts
+++ b/src/projects/dto/issues/create-issue.dto.ts
@@ -1,0 +1,55 @@
+import { IsNotEmpty, IsInt, IsDefined, IsArray, MaxLength, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CommentDto {
+  @IsNotEmpty({
+    message: 'The content of the first comment is required.',
+  })
+  @MaxLength(250, {
+    message: 'The length of the first comment\'s content must be less than or equal to 250.',
+  })
+  content: string;
+}
+
+export class CreateIssueDto {
+  @IsNotEmpty({
+    message: 'Title is required.',
+  })
+  @MaxLength(45, {
+    message: 'The length of title must be less than or equal to 45.'
+  })
+  readonly title: string;
+
+  @Type(() => CommentDto)
+  @ValidateNested({
+    message: 'The field comment must an object.',
+  })
+  @IsDefined({
+    message: 'The first comment is required.',
+  })
+  readonly comment: CommentDto;
+
+  @IsNotEmpty({
+    message: 'The field labels is required.',
+  })
+  @IsArray({
+    message: 'The field labels must be an array of integers.',
+  })
+  @IsInt({
+    each: true,
+    message: 'Each value of labels must be an integer.',
+  })
+  readonly labels: number[];
+
+  @IsNotEmpty({
+    message: 'The field asignees is required.',
+  })
+  @IsArray({
+    message: 'The field labels must be an array of integers.',
+  })
+  @IsInt({
+    each: true,
+    message: 'Each value of asignees must be an integer.',
+  })
+  readonly assignees: number[];
+}

--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -21,6 +21,7 @@ import { TransferProjectDto } from './dto/transfer-project.dto';
 import { PrivacyProjectDto } from './dto/privacy-project.dto';
 import { MemberIdDto } from './dto/member-id.dto';
 import { CreateLabelDto } from './dto/labels/create-label.dto';
+import { CreateIssueDto } from './dto/issues/create-issue.dto';
 import { ProjectsService } from './projects.service';
 import { Permission } from '../users/users.entity';
 import { AuthenticatedGuard } from '../common/guards/authenticated.guard';
@@ -385,5 +386,14 @@ export class ProjectsController {
           message: 'Cannot add the new label since there is another label having the same name.'
         });
     }
+  }
+
+  @UseGuards(AuthenticatedGuard)
+  @Post(':id/issues')
+  async createNewIssueToProject(
+    @Param('id', IdValidationPipe) projectId: number,
+    @Body(ValidationPipe) createIssueDto: CreateIssueDto,
+    @Request() request: ExpressRequest,
+  ) {
   }
 }

--- a/src/projects/projects.module.ts
+++ b/src/projects/projects.module.ts
@@ -6,6 +6,7 @@ import { ProjectsService } from './projects.service';
 import { TagsModule } from '../tags/tags.module';
 import { UsersModule } from '../users/users.module';
 import { LabelsModule } from '../labels/labels.module';
+import { IssuesModule } from '../issues/issues.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { LabelsModule } from '../labels/labels.module';
     UsersModule,
     TagsModule,
     LabelsModule,
+    IssuesModule,
   ],
   controllers: [ProjectsController],
   providers: [ProjectsService],


### PR DESCRIPTION
實作 `POST /api/projects/:id/issues`
使用者能夠透過 `id` 與 body 資料來在指定專案下建立新的 Issue
在建立 Issue 的同時也會該 Issue 下的一個新的 Comment

此路由處理了以下幾種情況：
- `401 Unauthorized`
    - 使用者未登入
- `400 Bad Request`
    - `id` 不為整數
    - `title` 留空 或 字數超過 45
    - `comment` 不存在
    - `comment.content` 留空 或 字數超過 250
    - `labels` 不為整數陣列
    - `assignees` 不為整數陣列
- `404 Not Found`
    - 找不到該專案
- `403 Forbidden`
    - 專案為 `private` 且使用者不為 專案成員 或是 管理員
    - `assignees` 中有任一位不為此專案成員
    - `labels` 中有任一個 Label 不屬於這個專案
- `201 Created`
    - 成功