### PR TITLE
Create a route for reading all issue ids of a project

### DIFF
--- a/src/projects/projects.controller.ts
+++ b/src/projects/projects.controller.ts
@@ -388,6 +388,30 @@ export class ProjectsController {
     }
   }
 
+  @Get(':id/issues')
+  async readAllIssues(
+    @Param('id', IdValidationPipe) projectId: number,
+    @Request() request: ExpressRequest,
+  ) {
+    const user: SessionUser | undefined = request.user as SessionUser;
+    const userId: number | undefined = user && user.id;
+    const permissesion: Permission | undefined = user && user.permission;
+
+    const [result, issueIds] = await this.projectsService.readAllIssueIds(
+      projectId,
+      userId,
+      permissesion,
+    );
+
+    if (result === OperationResult.NotFound) {
+      throw new NotFoundException({
+        message: 'The project does not exist.',
+      });
+    }
+
+    return { issues: issueIds };
+  }
+
   @UseGuards(AuthenticatedGuard)
   @Post(':id/issues')
   async createNewIssueToProject(

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -537,4 +537,31 @@ export class ProjectsService {
 
     return [OperationResult.Success, Resource.Issue];
   }
+
+  async readAllIssueIds(
+    projectId: number,
+    userId: number,
+    permission: Permission,
+  ): Promise<[OperationResult, number[]?]>
+  {
+    const project = await this.projectRepository.findOne(projectId, {
+      relations: ['participants', 'issues'],
+    });
+
+    if (!project) {
+      return [OperationResult.NotFound, null];
+    }
+
+    if (project.privacy === Privacy.Private) {
+      const { participants } = project;
+      const isAdmin = permission === Permission.Admin;
+      const isParticipant = participants.some(user => user.id === userId);
+      if (!isParticipant && !isAdmin) {
+        return [OperationResult.NotFound, null];
+      }
+    }
+
+    const issueIds = project.issues.map(issue => issue.id);
+    return [OperationResult.Success, issueIds];
+  }
 }


### PR DESCRIPTION
實作 `GET /api/projects/:id/issues`
使用者能夠透過 `id` 來取得在該專案下的所有 Issue `id`
管理員能夠取得任意專案下的所有 Issue `id`

此路由處理了以下幾種情況：
- `400 Bad Request`
    - `id` 不為整數
- `404 Not Found`
    - 專案不存在
    - 專案為 `private` 且使用者不為 專案成員 或是 管理員
- `200 OK`
    - 成功
```jsonld
{
    "issues": number[]
}
```