### PR TITLE
Create a route for reading an issue by id

### DIFF
--- a/src/issues/dto/read-issue.dto.ts
+++ b/src/issues/dto/read-issue.dto.ts
@@ -1,5 +1,6 @@
 export class ReadIssueDto {
   readonly title: string
+  readonly number: number
   readonly owner: number
   readonly labels: number[]
   readonly assignees: number[]

--- a/src/issues/dto/read-issue.dto.ts
+++ b/src/issues/dto/read-issue.dto.ts
@@ -1,0 +1,8 @@
+export class ReadIssueDto {
+  readonly title: string
+  readonly owner: number
+  readonly labels: number[]
+  readonly assignees: number[]
+  readonly createdTime: string
+  readonly updatedTime: string
+}

--- a/src/issues/issues.controller.spec.ts
+++ b/src/issues/issues.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { IssuesController } from './issues.controller';
+
+describe('Issues Controller', () => {
+  let controller: IssuesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [IssuesController],
+    }).compile();
+
+    controller = module.get<IssuesController>(IssuesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/issues/issues.controller.ts
+++ b/src/issues/issues.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Param, Request, NotFoundException } from '@nestjs/common';
+import { Request as ExpressRequest } from 'express';
+import { IssuesService } from './issues.service';
+import { Permission } from '../users/users.entity';
+import { IdValidationPipe } from '../common/pipes/id-validation.pipe';
+import { SessionUser } from '../common/types/session-user.type';
+import { OperationResult } from '../common/types/operation-result.type';
+
+@Controller('issues')
+export class IssuesController {
+  constructor(
+    private readonly issuesService: IssuesService,
+  ) { }
+
+  @Get(':id')
+  async readOneById(
+    @Param('id', IdValidationPipe) issueId: number,
+    @Request() request: ExpressRequest,
+  ) {
+    const user: SessionUser | undefined = request.user as SessionUser;
+    const userId: number | undefined = user && user.id;
+    const permission: Permission | undefined = user && user.permission;
+
+    const [result, readIssuesDto] = await this.issuesService.readOneById(
+      issueId,
+      userId,
+      permission,
+    );
+
+    if (result === OperationResult.NotFound) {
+      throw new NotFoundException({
+        message: 'The project does not exist.',
+      });
+    }
+
+    return readIssuesDto;
+  }
+}

--- a/src/issues/issues.module.ts
+++ b/src/issues/issues.module.ts
@@ -3,10 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Issue } from './issues.entity';
 import { IssuesService } from './issues.service';
 import { CommentsModule } from '../comments/comments.module';
+import { IssuesController } from './issues.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Issue]), CommentsModule],
   providers: [IssuesService],
   exports: [IssuesService],
+  controllers: [IssuesController],
 })
 export class IssuesModule {}

--- a/src/issues/issues.service.ts
+++ b/src/issues/issues.service.ts
@@ -74,7 +74,7 @@ export class IssuesService {
       .leftJoinAndSelect('issue.labels', 'labels')
       .leftJoinAndSelect('project.participants', 'participants')
       .where('issue.id = :issueId', { issueId })
-      .select(['issue.title', 'issue.createdTime', 'issue.updatedTime'])
+      .select(['issue.title', 'issue.number', 'issue.createdTime', 'issue.updatedTime'])
       .addSelect(['project.id', 'project.privacy'])
       .addSelect('participants.id')
       .addSelect('owner.id')
@@ -98,6 +98,7 @@ export class IssuesService {
     const readIssueDto: ReadIssueDto = {
       title: issue.title,
       owner: owner.id,
+      number: issue.number,
       labels: unwrapIdsFromObjects(labels),
       assignees: unwrapIdsFromObjects(assignees),
       createdTime: issue.createdTime.toJSON(),

--- a/src/issues/issues.service.ts
+++ b/src/issues/issues.service.ts
@@ -3,11 +3,19 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Issue } from './issues.entity'
 import { CreateIssueDto } from './dto/create-issue.dto';
+import { ReadIssueDto } from './dto/read-issue.dto';
 import { CommentsService } from '../comments/comments.service';
 import { CreateCommentDto } from '../comments/dto/create-comment.dto';
+import { Permission } from '../users/users.entity';
+import { OperationResult } from '../common/types/operation-result.type';
+import { Privacy } from 'src/projects/projects.entity';
 
 function wrapIdsIntoObjects(ids: number[]) {
   return ids.map(id => ({ id }));
+}
+
+function unwrapIdsFromObjects(objects: { id: number }[]) {
+  return objects.map(objId => objId.id);
 }
 
 @Injectable()
@@ -50,5 +58,51 @@ export class IssuesService {
       issueId: issue.id,
     };
     await this.commentsService.create(createCommentDto);
+  }
+
+  async readOneById(
+    issueId: number,
+    userId?: number,
+    permission?: Permission,
+  ): Promise<[OperationResult, ReadIssueDto?]>
+  {
+    const issue = await this.issueRepository
+      .createQueryBuilder('issue')
+      .leftJoinAndSelect('issue.project', 'project')
+      .leftJoinAndSelect('issue.owner', 'owner')
+      .leftJoinAndSelect('issue.assignees', 'assignees')
+      .leftJoinAndSelect('issue.labels', 'labels')
+      .leftJoinAndSelect('project.participants', 'participants')
+      .where('issue.id = :issueId', { issueId })
+      .select(['issue.title', 'issue.createdTime', 'issue.updatedTime'])
+      .addSelect(['project.id', 'project.privacy'])
+      .addSelect('participants.id')
+      .addSelect('owner.id')
+      .addSelect('assignees.id')
+      .addSelect('labels.id')
+      .getOne();
+
+    if (!issue) {
+      return [OperationResult.NotFound, null];
+    }
+
+    const { project, owner, assignees, labels } = issue;
+    if (project.privacy === Privacy.Private) {
+      const isParticipant = userId && project.participants.some(user => user.id === userId);
+      const isAdmin = permission && permission === Permission.Admin;
+      if (!isParticipant && !isAdmin) {
+        return [OperationResult.NotFound, null];
+      }
+    }
+
+    const readIssueDto: ReadIssueDto = {
+      title: issue.title,
+      owner: owner.id,
+      labels: unwrapIdsFromObjects(labels),
+      assignees: unwrapIdsFromObjects(assignees),
+      createdTime: issue.createdTime.toJSON(),
+      updatedTime: issue.updatedTime.toJSON(),
+    };
+    return [OperationResult.Success, readIssueDto];
   }
 }


### PR DESCRIPTION
實作 `GET /api/issues/:id`
使用者能透過 `id` 來取得指定 Issue 的資料

此路由處理了以下幾種情況：
- `400 Bad Request`
    - `id` 不為整數
- `404 Not Found`
    - Issue 實際不存在
    - Issue 所屬的 Project 為 `private` 且使用者不為 專案參與者 或 管理員
- `200 OK`
    - 成功
```jsonld
{
    "title": string,
    "number": number,
    "owner": number,
    "labels": number[],
    "assignees": number[]
    "createdTime": string,
    "updatedTime": string
}
```