### PR TITLE
Create a route for updating a issue

### DIFF
--- a/src/issues/dto/update-issue.dto.ts
+++ b/src/issues/dto/update-issue.dto.ts
@@ -1,0 +1,41 @@
+import { IsNotEmpty, MaxLength, IsArray, IsInt, ArrayUnique } from 'class-validator';
+
+export class UpdateIssueDto {
+  @IsNotEmpty({
+    message: 'Title is required.',
+  })
+  @MaxLength(45, {
+    message: 'The length of title must be less than or equal to 45.'
+  })
+  readonly title: string;
+
+  @IsNotEmpty({
+    message: 'The field labels is required.',
+  })
+  @IsArray({
+    message: 'The field labels must be an array of integers.',
+  })
+  @IsInt({
+    each: true,
+    message: 'Each value of labels must be an integer.',
+  })
+  @ArrayUnique({
+    message: 'Each value of labels must be unique.'
+  })
+  readonly labels: number[];
+
+  @IsNotEmpty({
+    message: 'The field asignees is required.',
+  })
+  @IsArray({
+    message: 'The field labels must be an array of integers.',
+  })
+  @IsInt({
+    each: true,
+    message: 'Each value of assignees must be an integer.',
+  })
+  @ArrayUnique({
+    message: 'Each value of assignees must be unique.'
+  })
+  readonly assignees: number[];
+}

--- a/src/issues/issues.controller.ts
+++ b/src/issues/issues.controller.ts
@@ -1,10 +1,14 @@
-import { Controller, Get, Param, Request, NotFoundException } from '@nestjs/common';
+import { Controller, Get, Put, Param, Body, Request, UseGuards, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { Request as ExpressRequest } from 'express';
 import { IssuesService } from './issues.service';
+import { UpdateIssueDto } from './dto/update-issue.dto';
 import { Permission } from '../users/users.entity';
+import { AuthenticatedGuard } from '../common/guards/authenticated.guard';
+import { ValidationPipe } from '../common/pipes/validation.pipe';
 import { IdValidationPipe } from '../common/pipes/id-validation.pipe';
 import { SessionUser } from '../common/types/session-user.type';
 import { OperationResult } from '../common/types/operation-result.type';
+import { Resource } from '../common/types/resource.type';
 
 @Controller('issues')
 export class IssuesController {
@@ -34,5 +38,44 @@ export class IssuesController {
     }
 
     return readIssuesDto;
+  }
+
+  @UseGuards(AuthenticatedGuard)
+  @Put(':id')
+  async updateOneById(
+    @Param('id', IdValidationPipe) issueId: number,
+    @Body(ValidationPipe) updateIssueDto: UpdateIssueDto, 
+    @Request() request: ExpressRequest,
+  ) {
+    const { id: userId, permission } = request.user as SessionUser;
+    const [result, resource] = await this.issuesService.updateOneById(
+      issueId,
+      updateIssueDto,
+      userId,
+      permission,
+    );
+
+    if (result === OperationResult.NotFound) {
+      throw new NotFoundException({
+        message: 'The issue does not exist.',
+      });
+    }
+
+    if (result === OperationResult.Forbidden) {
+      switch (resource) {
+        case Resource.Issue:
+          throw new ForbiddenException({
+            message: 'Cannot update the issue since you are not the owner of this issue or an participant of the project.',
+          });
+        case Resource.User:
+          throw new ForbiddenException({
+            message: 'Cannot update the issue since one or many of the assignees do not participate in the project.',
+          });
+        case Resource.Label:
+          throw new ForbiddenException({
+            message: 'Cannot update the issue since one or many of the labels do not belong to the project.',
+          });
+      }
+    }
   }
 }


### PR DESCRIPTION
實作 `PUT /api/issues/:id`
使用者能透過 `id` 與 body 中的資料來更新指定的 Issue

此路由處理了以下情況：
- `401 Unauthorized`
    - 使用者沒有登入
- `400 Bad Request`
    - `id` 不為整數
    - `title` 留空 或 字數超過 45
    - `labels` 不為整數陣列 或 陣列中有重複的元素
    - `assignees` 不為整數陣列 或 陣列中有重複的元素
- `404 Not Found`
    - 該 Issue 不存在
- `403 Forbidden`
    - 使用者不為 Issue 發起者、專案參與者、管理員
    - `labels` 內存有一或多個不屬於該專案的 Label
    - `assignees` 內存有一或多個非該專案之成員
- `200 OK`
    - 成功