### PR TITLE
Create a route for closing an issue

### DIFF
--- a/src/issues/issues.entity.ts
+++ b/src/issues/issues.entity.ts
@@ -33,7 +33,7 @@ export class Issue {
   title: string;
 
   @Column({ default: Status.Open })
-  status: string;
+  status: Status;
 
   @CreateDateColumn()
   createdTime: Date;


### PR DESCRIPTION
實作 `DELETE /api/issues/:id`
使用者能透過 `id` 來關閉指定 Issue

此路由處理了以下幾種狀態：
- `401 Unauthorized`
    - 使用者未登入
- `400 Bad Request`
    - `id` 不為整數
- `404 Not Found`
    - 找不到目標 Issue
- `403 Forbidden`
    - 使用者不為 議題發起者、專案參與者、管理員
- `204 No Content`
    - 成功