### PR TITLE
Create a route for reading all issues that the user involves

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -7,7 +7,6 @@ import {
   Body,
   Param,
   Query,
-  Response,
   Request,
   HttpStatus,
   HttpCode,
@@ -17,7 +16,7 @@ import {
   BadRequestException,
   ConflictException,
 } from '@nestjs/common';
-import { Request as ExpressRequest, Response as ExpressResponse } from 'express';
+import { Request as ExpressRequest } from 'express';
 import { UsersService } from './users.service';
 import { Permission } from './users.entity';
 import { RegisterUserDto } from './dto/register-user.dto';
@@ -132,5 +131,28 @@ export class UsersController {
     }
 
     return { projects: projectIds };
+  }
+
+  @Get(':id/issues')
+  async readAllIssues(
+    @Param('id', IdValidationPipe) targetUserId: number,
+    @Request() request: ExpressRequest,
+  ) {
+    const user: SessionUser | undefined = request.user as SessionUser;
+    const userId: number | undefined = user && user.id;
+    const permission: Permission | undefined = user && user.permission;
+    const [result, issueIds] = await this.usersService.readAllIssues(
+      targetUserId,
+      userId,
+      permission,
+    );
+
+    if (result === OperationResult.NotFound) {
+      throw new NotFoundException({
+        message: 'The user does not exist.',
+      });
+    }
+
+    return { issues: issueIds };
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,11 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { User, Status } from './users.entity';
+import { User, Status, Permission } from './users.entity';
 import { Repository } from 'typeorm';
 import { RegisterUserDto } from './dto/register-user.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { ReadProfileDto } from './dto/read-profile.dto';
 import { OperationResult } from '../common/types/operation-result.type';
+import { Project, Privacy } from '../projects/projects.entity';
+import { Issue } from '../issues/issues.entity';
 
 @Injectable()
 export class UsersService {
@@ -106,5 +108,100 @@ export class UsersService {
   private async checkUserExistenceById(userId: number): Promise<boolean> {
     const count = await this.userRepository.count({ id: userId });
     return count > 0;
+  }
+
+  async readAllIssues(
+    targetUserId: number,
+    userId?: number,
+    permission?: Permission,
+  ): Promise<[OperationResult, number[]?]>
+  {
+    const user = await this.userRepository
+      .createQueryBuilder('user')
+      .leftJoinAndSelect('user.assignedIssues', 'assignedIssues')
+      .leftJoinAndSelect('user.ownedIssues', 'ownedIssues')
+      .where('user.id = :targetUserId', { targetUserId })
+      .select(['user.id', 'assignedIssues.id', 'ownedIssues.id'])
+      .getOne();
+
+    if (!user) {
+      return [OperationResult.NotFound, null];
+    }
+
+    // Remove duplicated issue ids
+    const assignedIssueIds = user.assignedIssues.map(issue => issue.id);
+    const ownedIssueIds = user.ownedIssues.map(issue => issue.id);
+    const duplicatedItemIndexsOfA = [];
+    assignedIssueIds.forEach((issueId, index) => {
+      if (ownedIssueIds.includes(issueId)) {
+        duplicatedItemIndexsOfA.push(index);
+      }
+    });
+    duplicatedItemIndexsOfA.forEach(index => assignedIssueIds.splice(index, 1));
+    const uniqueIssueIds = assignedIssueIds.concat(ownedIssueIds);
+
+    // Return all issue ids directly if the user is an admin.
+    if (permission === Permission.Admin) {
+      return [OperationResult.Success, uniqueIssueIds];
+    }
+
+    // Get relationship between issues and projects
+    const manager = this.userRepository.manager;
+    const uniqueIssuesProjects = await manager.createQueryBuilder(Issue, 'issue')
+      .leftJoinAndSelect('issue.project', 'project')
+      .select(['issue.id', 'project.id', 'project.privacy'])
+      .where('issue.id IN :set', { set: [uniqueIssueIds] })
+      .getMany();
+
+    // Make project-issue Info.
+    const issueProjectList = uniqueIssuesProjects.map(issue => ({
+      issueId: issue.id,
+      projectId: issue.project.id,
+      isPublic: issue.project.privacy === Privacy.Public,
+    }));
+
+    // Make unique project id list.
+    const uniqueProjects = [];
+    issueProjectList.forEach((item) => {
+      const { projectId, isPublic } = item;
+      if (!uniqueProjects.some(item => item.id === projectId)) {
+        uniqueProjects.push({ projectId, isPublic });
+      }
+    });
+
+    // The function of checking whether the user is in the project.
+    const projectParticipationMap = {};
+
+    async function checkParticipant({ projectId, isPublic }) {
+      if (isPublic) { // The project is public
+        projectParticipationMap[projectId] = true;
+        return;
+      }
+
+      if (!userId) {  // The project is private and the user has not logged in.
+        projectParticipationMap[projectId] = false;
+        return;
+      }
+
+      // The user has logged in, then check whether the user is a participant of this project.
+      const count = await manager.count(Project, {
+        where: {
+          id: projectId,
+          participants: { id: userId },
+        },
+        relations: ['participants'],
+      });
+      projectParticipationMap[projectId] = count > 0;
+    }
+    const checkParticipantProcesses = uniqueProjects.map(item => checkParticipant(item));
+    await Promise.all(checkParticipantProcesses);
+
+    // Filter out invisible issues.
+    const visibleItem = issueProjectList.filter((pair) => {
+      return projectParticipationMap[pair.projectId];
+    });
+
+    const visibleIssueIds = visibleItem.map(item => item.issueId);
+    return [OperationResult.Success, visibleIssueIds];
   }
 }


### PR DESCRIPTION
實作 `GET /api/users/:id/issues`

使用者能夠取得目標使用者所參與或發起的 Issue
若使用者為管理員，則他能看到所有的 Issue
若使用者未登入，則他只能看到公開專案下目標使用者有參與或發起的 Issue
若使用者有登入，則他只能看到 公開專案 與 他有參與的專案下，目標使用者有參與或發起的 Issue

此路由處理的以下幾種情況：
- `400 Bad Request`
    - `id` 不為整數
- `404 Not Found`
    - 目標使用者不存在
- `200 OK`
```jsonld
{
    "issues": number[]
}
```