### PR TITLE
Create a new comment of an issue

### DIFF
--- a/src/issues/dto/create-comment.dto.ts
+++ b/src/issues/dto/create-comment.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateCommentDto {
+  @IsNotEmpty({
+    message: 'Content is required.',
+  })
+  @IsString({
+    message: 'The type of content must be a string.',
+  })
+  readonly content: string
+}

--- a/src/issues/issues.controller.ts
+++ b/src/issues/issues.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Post,
   Put,
   Delete,
   Param,
@@ -15,6 +16,7 @@ import {
 import { Request as ExpressRequest } from 'express';
 import { IssuesService } from './issues.service';
 import { UpdateIssueDto } from './dto/update-issue.dto';
+import { CreateCommentDto } from './dto/create-comment.dto';
 import { Permission } from '../users/users.entity';
 import { AuthenticatedGuard } from '../common/guards/authenticated.guard';
 import { ValidationPipe } from '../common/pipes/validation.pipe';
@@ -115,6 +117,28 @@ export class IssuesController {
         throw new NotFoundException({
           message: 'Cannot close this issue since you are not the owner nor a participant of this project.',
         });
+    }
+  }
+
+  @UseGuards(AuthenticatedGuard)
+  @Post(':id/comments')
+  async createComment(
+    @Param('id', IdValidationPipe) issueId: number,
+    @Body(ValidationPipe) createCommentDto: CreateCommentDto,
+    @Request() request: ExpressRequest,
+  ) {
+    const { id: userId, permission } = request.user as SessionUser;
+    const result = await this.issuesService.createComment(
+      issueId,
+      createCommentDto,
+      userId,
+      permission,
+    );
+
+    if (result === OperationResult.NotFound) {
+      throw new NotFoundException({
+        message: 'The issue does not exist.',
+      });
     }
   }
 }


### PR DESCRIPTION
實作 `POST /api/issues/:id/comments`
使用者能透過 `id` 與 body 資料來在該 Issue 中建立 Comment

此路由處理了一下幾種情況：
- `401 Unauthorized`
    - 使用者未登入
- `400 Bad Request`
    - `id` 不為整數
    - `content` 不為空
- `404 Not Found`
    - Issue 不存在
    - Issue 所在的專案為 `private` 且使用者不為專案參與者 或是 管理員
- `201 Created`
    - 成功