### PR TITLE
Create a route for reading all comment ids of an issue

### DIFF
--- a/src/issues/issues.controller.ts
+++ b/src/issues/issues.controller.ts
@@ -141,4 +141,27 @@ export class IssuesController {
       });
     }
   }
+
+  @Get(':id/comments')
+  async readAllComment(
+    @Param('id', IdValidationPipe) issueId: number,
+    @Request() request: ExpressRequest,
+  ) {
+    const user: SessionUser | undefined = request.user as SessionUser;
+    const userId: number | undefined = user && user.id;
+    const permission: Permission | undefined = user && user.permission;
+    const [result, commentIds] = await this.issuesService.readAllComments(
+      issueId,
+      userId,
+      permission,
+    );
+
+    if (result === OperationResult.NotFound) {
+      throw new NotFoundException({
+        message: 'The issue does not exist.',
+      });
+    }
+
+    return { comments: commentIds };
+  }
 }


### PR DESCRIPTION
實作 `GET /api/issues/:id/comments`
使用者能透過 `id` 來取得目標 Issue 底下的所有 Comment Id

此路由處理了以下幾種情況：
- `401 Unauthorized`
    - 使用者未登入
- `400 Bad Request`
    - `id` 不為整數
    - `content` 不為空
- `404 Not Found`
    - Issue 不存在
    - Issue 所在的專案為 `private` 且使用者不為專案參與者 或是 管理員
- `201 Created`
    - 成功