### PR TITLE
Create a route for reading a comment by its id

### DIFF
--- a/src/comments/comments.controller.spec.ts
+++ b/src/comments/comments.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommentsController } from './comments.controller';
+
+describe('Comments Controller', () => {
+  let controller: CommentsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CommentsController],
+    }).compile();
+
+    controller = module.get<CommentsController>(CommentsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Param, Body, Request, NotFoundException } from '@nestjs/common';
+import { Request as ExpressRequest } from 'express';
+import { CommentsService } from './comments.service';
+import { Permission } from '../users/users.entity';
+import { IdValidationPipe } from '../common/pipes/id-validation.pipe';
+import { SessionUser } from '../common/types/session-user.type';
+import { OperationResult } from 'src/common/types/operation-result.type';
+
+@Controller('comments')
+export class CommentsController {
+  constructor(
+    private readonly commentsService: CommentsService,
+  ) { }
+
+  @Get(':id')
+  async readOneById(
+    @Param('id', IdValidationPipe) commentId: number,
+    @Request() request: ExpressRequest,
+  ) {
+    const user: SessionUser | undefined = request.user as SessionUser;
+    const userId: number | undefined = user && user.id;
+    const permission: Permission | undefined = user && user.permission;
+    const [result, readCommentDto] = await this.commentsService.readOneById(
+      commentId,
+      userId,
+      permission,
+    );
+
+    if (result === OperationResult.NotFound) {
+      throw new NotFoundException({
+        message: 'The comment does not exist.',
+      });
+    }
+
+    return readCommentDto;
+  }
+}

--- a/src/comments/comments.module.ts
+++ b/src/comments/comments.module.ts
@@ -2,10 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Comment } from './comments.entity';
 import { CommentsService } from './comments.service';
+import { CommentsController } from './comments.controller';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Comment])],
   providers: [CommentsService],
   exports: [CommentsService],
+  controllers: [CommentsController],
 })
 export class CommentsModule {}

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -3,6 +3,10 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Comment } from './comments.entity';
 import { CreateCommentDto } from './dto/create-comment.dto';
+import { ReadCommentDto } from './dto/read-comment.dto';
+import { Permission } from '../users/users.entity';
+import { Privacy } from '../projects/projects.entity';
+import { OperationResult } from '../common/types/operation-result.type';
 
 @Injectable()
 export class CommentsService {
@@ -19,5 +23,43 @@ export class CommentsService {
     });
 
     await this.commentRepository.save(comment);
+  }
+
+  async readOneById(
+    commentId: number,
+    userId?: number,
+    permission?: Permission,
+  ): Promise<[OperationResult, ReadCommentDto?]>
+  {
+    const comment = await this.commentRepository
+      .createQueryBuilder('comment')
+      .leftJoinAndSelect('comment.owner', 'owner')
+      .leftJoinAndSelect('comment.issue', 'issue')
+      .leftJoinAndSelect('issue.project', 'project')
+      .leftJoinAndSelect('project.participants', 'participant')
+      .where('comment.id = :commentId', { commentId })
+      .select(['comment', 'issue.id', 'project.id',
+        'project.privacy', 'participant.id', 'owner.id'])
+      .getOne();
+
+    if (!comment) {
+      return [OperationResult.NotFound, null];
+    }
+
+    const project = comment.issue.project;
+    const isPrivate = project.privacy === Privacy.Private;
+    const isParticipant = project.participants.some(user => user.id === userId);
+    const isAdmin = permission === Permission.Admin;
+    if (!isAdmin && isPrivate && !isParticipant) {
+      return [OperationResult.NotFound, null];
+    }
+
+    const readCommentDto: ReadCommentDto = {
+      content: comment.content,
+      owner: comment.owner.id,
+      createdTime: comment.createdTime.toJSON(),
+      updatedTime: comment.updatedTime.toJSON(),
+    };
+    return [OperationResult.Success, readCommentDto];
   }
 }

--- a/src/comments/dto/read-comment.dto.ts
+++ b/src/comments/dto/read-comment.dto.ts
@@ -1,0 +1,6 @@
+export class ReadCommentDto {
+  readonly content: string;
+  readonly owner: number;
+  readonly createdTime: string;
+  readonly updatedTime: string;
+}


### PR DESCRIPTION
實作 `GET /api/comments/:id`
使用者能透過 `id` 去取得指定 Comment 資料

此路由處理以下幾種情況：
- `400 Bad Request`
    - `id` 不為整數
- `404 Bad Request`
    - 指定的 Comment 不存在
    - Comment 存在，但使用者不為 Comment 所在專案之下的 專案參與者 且 不為管理員
- `200 OK`
    - 成功
```json
{
    "content": string,
    "owner": number,
    "createdTime": string,
    "updatedTime": string
}
```