### PR TITLE
Create a route for updating a comment by its id

### DIFF
--- a/src/comments/dto/update-comment.dto.ts
+++ b/src/comments/dto/update-comment.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class UpdateCommentDto {
+  @IsNotEmpty({
+    message: 'Content is required.',
+  })
+  @IsString({
+    message: 'The type of content must be a string',
+  })
+  readonly content: string;
+}


### PR DESCRIPTION
實作 `PUT /api/comments/:id`
使用者能夠透過 `id` 與 body 中的資料將指定的 Comment 內容更新了

此路由處理了以下邏輯：
- `401 Unauthorized`
    - 使用者未登入
- `400 Bad Request`
    - `id` 不為整數
    - `content` 為空
- `404 Not Found`
    - 目標 Issue 不存在
    - Issue 存在的所屬專案為 `private` 且使用者不為 Comment 擁有者 或 管理員
- `403 Forbidden`
    - 專案為 `public` 且使用者不為 Comment 擁有者 與 管理員
    - 專案為 `private` 且使用者為專案參與者 但 不為 Comment 擁有者 或 管理員
- `200 OK`
    - 成功