### PR TITLE
Create a route for updating a comment's status by id

### DIFF
--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -12,6 +12,7 @@ import {
 import { Request as ExpressRequest } from 'express';
 import { CommentsService } from './comments.service';
 import { UpdateCommentDto } from './dto/update-comment.dto';
+import { UpdateCommentStatusDto } from './dto/update-comment-status.dto';
 import { Permission } from '../users/users.entity';
 import { AuthenticatedGuard } from '../common/guards/authenticated.guard';
 import { IdValidationPipe } from '../common/pipes/id-validation.pipe';
@@ -71,6 +72,34 @@ export class CommentsController {
       case OperationResult.Forbidden:
         throw new ForbiddenException({
           message: 'Cannot modify this comment since you are not the owner of this comment.',
+        });
+    }
+  }
+
+  @UseGuards(AuthenticatedGuard)
+  @Put(':id/status')
+  async updateStatusById(
+    @Param('id', IdValidationPipe) commentId: number,
+    @Body(ValidationPipe) updateCommentStatusDto: UpdateCommentStatusDto,
+    @Request() request: ExpressRequest,
+  ) {
+    const { id: userId, permission } = request.user as SessionUser;
+    const { status } = updateCommentStatusDto;
+    const result = await this.commentsService.updateStatusById(
+      commentId,
+      status,
+      userId,
+      permission,
+    );
+
+    switch (result) {
+      case OperationResult.NotFound:
+        throw new NotFoundException({
+          message: 'The comment does not exist.',
+        });
+      case OperationResult.Forbidden:
+        throw new ForbiddenException({
+          message: 'Cannot update the status since you are not the project owner.',
         });
     }
   }

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Comment } from './comments.entity';
+import { Comment, Status } from './comments.entity';
 import { CreateCommentDto } from './dto/create-comment.dto';
 import { ReadCommentDto } from './dto/read-comment.dto';
 import { UpdateCommentDto } from './dto/update-comment.dto';
@@ -104,6 +104,47 @@ export class CommentsService {
     await this.commentRepository.update({ id: userId }, {
       content: updateCommentDto.content,
     });
+    return OperationResult.Success;
+  }
+
+  async updateStatusById(
+    commentId: number,
+    status: Status,
+    userId: number,
+    permission: Permission,
+  ): Promise<OperationResult>
+  {
+    const comment = await this.commentRepository
+      .createQueryBuilder('comment')
+      .leftJoinAndSelect('comment.issue', 'issue')
+      .leftJoinAndSelect('issue.project', 'project')
+      .leftJoinAndSelect('project.owner', 'owner')
+      .leftJoinAndSelect('project.participants', 'participant')
+      .where('comment.id = :commentId', { commentId })
+      .select(['comment.id', 'issue.id', 'project.privacy', 'owner.id', 'participant.id'])
+      .getOne();
+    
+    if (!comment) {
+      return OperationResult.NotFound;
+    }
+
+    const project = comment.issue.project;
+    const isPublic = project.privacy === Privacy.Public;
+    const isProjectOwner = project.owner.id === userId;
+    const isParticipant = project.participants.some(user => user.id === userId);
+    const isAdmin = permission === Permission.Admin;
+    if (isPublic) {
+      if (!isProjectOwner && !isAdmin) {
+        return OperationResult.Forbidden;
+      }
+    }
+    else {
+      if (!isProjectOwner && !isAdmin) {
+        return isParticipant ? OperationResult.Forbidden : OperationResult.NotFound;
+      }
+    }
+
+    await this.commentRepository.update({ id: commentId }, { status });
     return OperationResult.Success;
   }
 }

--- a/src/comments/dto/update-comment-status.dto.ts
+++ b/src/comments/dto/update-comment-status.dto.ts
@@ -1,0 +1,9 @@
+import { IsEnum } from 'class-validator';
+import { Status } from '../comments.entity';
+
+export class UpdateCommentStatusDto {
+  @IsEnum(Status, {
+    message: 'The value of status is invalid.',
+  })
+  readonly status: Status
+}


### PR DESCRIPTION
實作 `PUT /api/comments/:id/status`
使用者能夠 `id` 與 body 內容來將指定的 comment 狀態更新

此路由處理了以下幾種情況：
- `401 Unauthorized`
    - 使用者未登入
- `400 Bad Request`
    - `id` 不為整數
    - `status` 不為整數 `0` 或 `1`
- `404 Not Found`
    - Comment 實際不存在
    - Comment 存在且其所在的專案為 `private`，但使用者不為 專案擁有者、管理員
- `403 Forbidden`
    - Comment 所屬專案為 `public` 且使用者不為 專案擁有者 與 管理員
    - Comment 所屬專案為 `private` 且使用者為該專案成員 但 不為 專案擁有者 與 管理員
- `200 OK`
    - 成功