### PR TITLE
Search projects by a name

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { SessionModule } from './session/session.module';
 import { LabelsModule } from './labels/labels.module';
 import { IssuesModule } from './issues/issues.module';
 import { CommentsModule } from './comments/comments.module';
+import { QueryModule } from './query/query.module';
 
 const {
   DB_HOST,
@@ -49,6 +50,7 @@ const {
     LabelsModule,
     IssuesModule,
     CommentsModule,
+    QueryModule,
   ],
 })
 export class AppModule {}

--- a/src/projects/projects.service.ts
+++ b/src/projects/projects.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, Not, Brackets } from 'typeorm';
+import { Repository, Not, Brackets, Like } from 'typeorm';
 import { Project, Status, Privacy } from './projects.entity';
 
 import { CreateProjectDto } from './dto/create-project.dto';
@@ -566,5 +566,16 @@ export class ProjectsService {
 
     const issueIds = project.issues.map(issue => issue.id);
     return [OperationResult.Success, issueIds];
+  }
+
+  async searchManyByName(name: string): Promise<number[]> {
+    const projects = await this.projectRepository
+      .createQueryBuilder('project')
+      .where('project.name LIKE :name', { name: `%${name}%` })
+      .select('project.id')
+      .getMany();
+
+      const projectIds = projects.map(project => project.id);
+      return projectIds;
   }
 }

--- a/src/query/dto/query-project.dto.ts
+++ b/src/query/dto/query-project.dto.ts
@@ -1,0 +1,3 @@
+export class QueryProjectDto {
+  readonly name: string;
+}

--- a/src/query/query.controller.spec.ts
+++ b/src/query/query.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { QueryController } from './query.controller';
+
+describe('Query Controller', () => {
+  let controller: QueryController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [QueryController],
+    }).compile();
+
+    controller = module.get<QueryController>(QueryController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/query/query.controller.ts
+++ b/src/query/query.controller.ts
@@ -1,6 +1,9 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Controller, Get, Query, Request } from '@nestjs/common';
+import { Request as ExpressRequest } from 'express';
 import { QueryProjectDto } from './dto/query-project.dto';
 import { ProjectsService } from '../projects/projects.service';
+import { Permission } from '../users/users.entity';
+import { SessionUser } from '../common/types/session-user.type';
 
 @Controller('query')
 export class QueryController {
@@ -9,11 +12,21 @@ export class QueryController {
   ) { }
 
   @Get('projects')
-  async queryProject(@Query() queryProjectDto: QueryProjectDto) {
+  async queryProject(
+    @Query() queryProjectDto: QueryProjectDto,
+    @Request() request: ExpressRequest,
+  ) {
+    const user: SessionUser | undefined = request.user as SessionUser;
+    const userId: number | undefined = user && user.id;
+    const permission: Permission | undefined = user && user.permission;
     const name: string | undefined = queryProjectDto.name;
     let projectIds: number[] = [];
     if (typeof name === 'string') {
-      projectIds = await this.projectsService.searchManyByName(name);
+      projectIds = await this.projectsService.searchManyByName(
+        name,
+        userId,
+        permission,
+      );
     }
     return { projects: projectIds };
   }

--- a/src/query/query.controller.ts
+++ b/src/query/query.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { QueryProjectDto } from './dto/query-project.dto';
+import { ProjectsService } from '../projects/projects.service';
+
+@Controller('query')
+export class QueryController {
+  constructor(
+    private readonly projectsService: ProjectsService,
+  ) { }
+
+  @Get('projects')
+  async queryProject(@Query() queryProjectDto: QueryProjectDto) {
+    const name: string | undefined = queryProjectDto.name;
+    let projectIds: number[] = [];
+    if (typeof name === 'string') {
+      projectIds = await this.projectsService.searchManyByName(name);
+    }
+    return { projects: projectIds };
+  }
+}

--- a/src/query/query.module.ts
+++ b/src/query/query.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { QueryController } from './query.controller';
+import { ProjectsModule } from '../projects/projects.module';
+
+@Module({
+  imports: [ProjectsModule],
+  controllers: [QueryController],
+})
+export class QueryModule {}


### PR DESCRIPTION
實作 `GET /api/query/projects?name=<project_name>`
使用者能夠透過專案名稱或部份名稱來搜尋一或多個專案

回傳 `200 OK` 且 body 形式為：
```jsonld
{
    "projects": number[]
}
```